### PR TITLE
If xmlstarlet fails, the script will fail

### DIFF
--- a/src/main/shell/certs-manager/download_tsl_it_certs.sh
+++ b/src/main/shell/certs-manager/download_tsl_it_certs.sh
@@ -174,7 +174,7 @@ parse_and_save_certs() {
   # Check if the XPath found any nodes
   if [ -z "${certs}" ]; then
     print_msg "${RED}" "❌ XPath set is empty. Please check the XML structure and XPath expression."
-    return
+    exit 1
   fi
 
   if [ $VERBOSE -eq 1 ]; then

--- a/src/main/shell/certs-manager/download_tsl_it_certs.sh
+++ b/src/main/shell/certs-manager/download_tsl_it_certs.sh
@@ -173,7 +173,7 @@ parse_and_save_certs() {
 
   # Check if the XPath found any nodes
   if [ -z "${certs}" ]; then
-    print_msg "${RED}" "❌ XPath set is empty. Please check the XML structure and XPath expression."
+    print_msg "${RED}" "❌ XPath set is empty. Please check the XML structure and XPath expression. (check your xmlstarlet version, minimum required version 1.6.1, compiled against libxml2 2.9.14 and libxslt 1.1.35)."
     exit 1
   fi
 


### PR DESCRIPTION
This is a partial solution to issue : https://github.com/amusarra/quarkus-mtls-auth/issues/1

The script will still fail but cause overal build failure.

Still trying to understand why xmlstarlet get the error on my system.